### PR TITLE
add tailupgrade to convert html to v.1.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,7 @@ Tailwind CSS is a utility-first CSS framework for rapidly building custom user i
 - [Tailwind CSS Styled Snippets for VS Code](https://marketplace.visualstudio.com/items?itemName=muhajirframe.tailwind-styled-snippets)
 - [Tailwind CSS IntelliSense for (neo)vim](https://github.com/iamcco/coc-tailwindcss)
 - [Tailwind Button Playground](https://minthemiddle.github.io/tailwind-button-playground/)
+- [Tailupgrade](https://www.npmjs.com/package/tailupgrade) : Convert HTML files with tailwind V.0.x class name into stable version V.1.x
 - [Add Your Item](https://github.com/merchedhq/awesome-tailwindcss/pulls)
 
 


### PR DESCRIPTION
We use this small tool to convert our collection Tailwindcss component snippet html files which mostly written prior to Tailwind version 1.0. It's already published into NPM for easy install and use. 