### PR TITLE
Add new Open Source project: LeagueStats

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -184,6 +184,7 @@
 - [Goodwork](https://github.com/iluminar/goodwork) - Project Management & Collaboration tool.
 - [Statusfy](https://github.com/bazzite/statusfy) - Status page system using Tailwind CSS.
 - [Todolist](https://github.com/guillaumebriday/todolist-frontend-vuejs) - To-do list application using Tailwind CSS.
+- [LeagueStats](https://github.com/vkaelin/LeagueStats) - Statistics website for League of Legends players.
 
 ### Learning
 


### PR DESCRIPTION
Add https://github.com/vkaelin/LeagueStats to the list of open projects.

I was wondering 2 things:

- Should I post it in the websites list or in the open projects list ?
- Should I link to the homepage or directly to a player's page to have a better idea of the website (e.g. https://leaguestats.gg/summoner/euw/Alderiate)

Let me know and I will make the changes, thanks!