### PR TITLE
Add `tailwindcss-scroll-snap`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@
 - [Debug Screens](https://github.com/jorenvanhee/tailwindcss-debug-screens) - Adds a component that shows the currently active screen (responsive breakpoint).
 - [Dark Mode with Class](https://github.com/danestves/tailwindcss-darkmode) - Adds `dark` variants based on CSS classes.
 - [CSS Logical Properties](https://github.com/omarkhatibco/tailwind-css-logical-properties) - Generate classnames for CSS Logical Properties for margin, padding, border-width, border-raduis, text-align, float & writing-mode.
+- [CSS Scroll Snap](https://github.com/hawezo/tailwindcss-scroll-snap) - Adds `scroll-snap` utilities.
 
 > 🛑 - _The functionalities these plugins below offer have been fully or partially implemented in the latest Tailwind CSS versions._
 


### PR DESCRIPTION
https://github.com/hawezo/tailwindcss-scroll-snap 

I made this some time ago and it's useful to some people, so maybe it should be featured here. It's a simple plugin that adds `scroll-snap` utilities to Tailwind.