### PR TITLE
Add "@tailwindcssinjs/macro"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -144,6 +144,7 @@
 - 🌍🔧 [TailwindCSS Palette Generator](https://tailwindcss-palette-generator.coderello.com/) - Palette generator for Tailwind CSS (online).
 - 💼 [@nuxtjs/tailwindcss](https://github.com/nuxt-community/tailwindcss-module) - Tailwind CSS module for NuxtJS with PurgeCSS and modern CSS (preset env 1).
 - 💼 [preact-cli-tailwind](https://github.com/agneym/preact-cli-tailwind) - Adds Tailwind CSS module as PostCSS plugin and sets up PurgeCSS in production for PreactJS CLI Projects.
+- 💼🔧 [@tailwindcssinjs/macro](https://github.com/Arthie/tailwindcssinjs) - Babel macro that transforms Tailwind CSS classes into css object styles for css-in-js libraries.
 
 | Emoji | Description                                    |
 | ----- | ---------------------------------------------- |

--- a/readme.md
+++ b/readme.md
@@ -144,7 +144,7 @@
 - 🌍🔧 [TailwindCSS Palette Generator](https://tailwindcss-palette-generator.coderello.com/) - Palette generator for Tailwind CSS (online).
 - 💼 [@nuxtjs/tailwindcss](https://github.com/nuxt-community/tailwindcss-module) - Tailwind CSS module for NuxtJS with PurgeCSS and modern CSS (preset env 1).
 - 💼 [preact-cli-tailwind](https://github.com/agneym/preact-cli-tailwind) - Adds Tailwind CSS module as PostCSS plugin and sets up PurgeCSS in production for PreactJS CLI Projects.
-- 💼🔧 [@tailwindcssinjs/macro](https://github.com/Arthie/tailwindcssinjs) - Babel macro that transforms Tailwind CSS classes into css object styles for css-in-js libraries.
+- 💼🔧 [@tailwindcssinjs/macro](https://github.com/Arthie/tailwindcssinjs) - Babel macro that transforms Tailwind CSS classes into objects for CSS-in-JS libraries.
 
 | Emoji | Description                                    |
 | ----- | ---------------------------------------------- |


### PR DESCRIPTION
Hello!
I added "@tailwindcssinjs/macro" to the tools section.

Package description:
@tailwindcssinjs/marco is a babel macro that transforms Tailwind classes into css object styles. These css object styles can be used with your favorite css-in-js library.

Full disclosure: I am the author of this package.