### PR TITLE
Added 'Create React App Template with Tailwind CSS + TypeScript'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -182,7 +182,7 @@
 - 🎨 [Tailwind Admin](https://github.com/tailwindadmin/admin) - Administration panel template with Tailwind CSS.
 - 🎨 [Wordpress Tailwind CSS + Google PWA](https://github.com/ri7nz/Mesjid) - Wordpress Theme and PWA using Tailwind CSS.
 - 🎨 [Seminyak Hugo Theme](https://git.habd.as/jhabdas/seminyak) - Hugo Theme using Tailwind CSS.
-- 🎨 [Create React App Template with Tailwind CSS + TypeScript](https://github.com/dance2die/cra-template-tailwindcss-typescript)
+- 🎨 [Create React App Template with Tailwind CSS + TypeScript](https://github.com/dance2die/cra-template-tailwindcss-typescript) - CRA Template to  add Tailwind CSS + TypeScript support.
 
 ### IDE Extensions
 

--- a/readme.md
+++ b/readme.md
@@ -182,6 +182,7 @@
 - 🎨 [Tailwind Admin](https://github.com/tailwindadmin/admin) - Administration panel template with Tailwind CSS.
 - 🎨 [Wordpress Tailwind CSS + Google PWA](https://github.com/ri7nz/Mesjid) - Wordpress Theme and PWA using Tailwind CSS.
 - 🎨 [Seminyak Hugo Theme](https://git.habd.as/jhabdas/seminyak) - Hugo Theme using Tailwind CSS.
+- 🎨 [Create React App Template with Tailwind CSS + TypeScript](https://github.com/dance2die/cra-template-tailwindcss-typescript)
 
 ### IDE Extensions
 


### PR DESCRIPTION
Hi folks.

I added my [Create React App](https://create-react-app.dev/) (CRA) template, which you can use it with the CRA CLI (command line interface).

FYI - The linked template can be used like following.

```bash
npx create-react-app my-app --template tailwindcss-typescript
```