### PR TITLE
Fixed typos to match our guidelines

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -102,10 +102,10 @@
 - [Tailwind Toolbox](https://www.tailwindtoolbox.com) - Tailwind CSS templates, components and resources.
 - [Tailwind Templates](https://www.tailwindtemplates.io) - Tailwind CSS components.
 - [jQuery + Tailwind Checkbox Toggle](https://craigerskine.github.io/jquery-tailwind-checkbox-toggle) - Switches using jQuery and Tailwind CSS.
-- [Tailwind Starter Kit](https://www.creative-tim.com/learning-lab/tailwind-starter-kit#/presentation?ref=awesome-tailwindcss) - Tailwind Starter Kit is an extension for TailwindCSS, Free and Open Source.
+- [Tailwind Starter Kit](https://www.creative-tim.com/learning-lab/tailwind-starter-kit#/presentation?ref=awesome-tailwindcss) - Tailwind Starter Kit is an extension for Tailwind CSS, Free and Open Source.
 - [a17t](https://a17t.miles.land) - Atomic design toolkit built to extend Tailwind CSS.
 - [Tailwind Blocks](https://mert.dev/tailwind-blocks) - Tailwind CSS UI blocks for landing pages.
-- [Meraki UI Components](https://merakiui.com) - Beautiful Tailwindcss components that support RTL languages.
+- [Meraki UI Components](https://merakiui.com) - Beautiful Tailwind CSS components that support RTL languages.
 
 ## Resources
 


### PR DESCRIPTION
We use `Tailwind CSS` to refer to the framework, not `TailwindCSS`.