### PR TITLE
add Tailwind CSS bootstrap grid plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,7 @@
 - [Background svg](https://github.com/AndersNielsen85/tailwindcss-bg-svg) - Inject svgs as background images with color variants.
 - [Brand Colors](https://github.com/praveenjuge/tailwindcss-brand-colors) - Adds various brand colors for background, border and text.
 - [Padded Radius](https://github.com/locksten/tailwindcss-padded-radius) - Adds variants for matching nested border radii.
+- [Bootstrap Grid](https://github.com/karolis-sh/tailwind-bootstrap-grid) - Generates Bootstrap's style flexbox grid system.
 
 > 🛑 - _The functionalities these plugins below offer have been fully or partially implemented in the latest Tailwind CSS versions._
 


### PR DESCRIPTION
Added link to Tailwind CSS bootstrap's flexbox grid [plugin](https://github.com/karolis-sh/tailwind-bootstrap-grid).