### PR TITLE
add(plugin): CSS Filter & Backdrop Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@
 - 💼 [Background SVG](https://github.com/AndersNielsen85/tailwindcss-bg-svg) - Inject SVGs as background images with color variants.
 - 💼 [Brand Colors](https://github.com/praveenjuge/tailwindcss-brand-colors) - Adds various brand colors for background, border and text.
 - 💼 [Bootstrap Grid](https://github.com/karolis-sh/tailwind-bootstrap-grid) - Generates Bootstrap's style flexbox grid system.
+- 💼 [CSS Filters](https://github.com/Larsklopstra/tailwindcss-css-filters) - Adds `filter` and `backdrop-filter` utilities with defaults.
 - 🧬 [Pseudo](https://github.com/Log1x/tailwindcss-pseudo) - Adds custom variants to Tailwind CSS's configuration.
 - 🧬 [Direction](https://github.com/RonMelkhior/tailwindcss-dir) - Adds `RTL` and `LTR` variants.
 - 🧬 [Touch](https://github.com/SteadfastCollective/tailwindcss-touch) - Adds `touch` variants.


### PR DESCRIPTION
| Name                 | Link                 |
| -------------------- | -------------------- |
| Tailwind CSS Filters | https://github.com/Larsklopstra/tailwindcss-css-filters |

This plugin adds CSS `filters` and `backdrop-filters` to Tailwind CSS with defaults.

Example:

```html
<img src="my-cool-image.png" class="filter-grayscale-50 filter-contrast-75" />

<div class="bg-white bg-opacity-25 bdf-blur-8 bdf-saturate-125">
  ...
</div>
```

---

- [x] My item is in the right category
- [x] My item is logically grouped below similar items
- [x] My item's name and description respects the conventions of the list
- [x] My item is awesome
- [x] I have read and followed the [contribution guidelines](.github/CONTRIBUTING.md)
