### PR TITLE
fix(tools): update name and description of Tailwind CSS v2 colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@
 - 🎨🌍🔧 [Grayscale Design](https://grayscale.design/) - A Luminance-based color palette generator.
 - 🎨🌍🔧 [Hypercolor](https://hypercolor.dev/) - Collection of pre-configured Tailwind CSS gradients with directional options.
 - 🎨🌍🔧 [Palettolithic](https://palettolithic.com) - Generates harmonius color palettes based on one color.
-- 🎨🌍🔧 [TailwindCSS Colors v2.0](https://www.figma.com/community/file/905719775911766776) - TailwindCSS Colors v2.0 Library for Figma.
+- 🎨🌍💼 [Tailwind CSS v2 colors](https://www.figma.com/community/file/905719775911766776) - Figma library with Tailwind CSS v2 colors.
 - 🌍🔧 [GPT-3 Tailwind CSS code generator](http://gpt-tailwind.com/) - OpenAI GPT-3 powered Tailwind CSS code generator.
 - 🌍🔧 [Stitches](https://stitches.hyperyolo.com/) - Template generator with Tailwind (online).
 - 🌍🔧 [tail-animista](https://tail-animista.vercel.app) - Configurable custom animation utilities generator for Tailwind CSS.


### PR DESCRIPTION
I was too late for the review of https://github.com/aniftyco/awesome-tailwindcss/pull/319. I'm just fixing the name (for consistency, `TailwindCSS` vs `Tailwind CSS`) and its description for clarity. 

Thanks and sorry for the bother.