### PR TITLE
add(plugins): official Aspect Ratio and Forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@
 **Legend**: 💙 Official plugin · 🎨 Theming · 💼 Utilities · 🧬 Variants · 🧩 Components · 🛑 Deprecated
 
 - 💙🧩 [Typography](https://github.com/tailwindlabs/tailwindcss-typography) - Adds a `prose` class for beautiful typographic defaults.
-- 💙🧩 [Custom Forms](https://github.com/tailwindlabs/tailwindcss-custom-forms) - Adds better default styles to form elements.
+- 💙💼 [Aspect Ratio](https://github.com/tailwindlabs/tailwindcss-aspect-ratio) - Adds composable aspect ratio utilities.
+- 💙 [Forms](https://github.com/tailwindlabs/tailwindcss-forms) - Adds better default styles to form elements.
 - 🎨🧬 [Theming](https://github.com/innocenzi/tailwindcss-theming) - Theming using CSS variables, with dark mode support.
 - 🎨🧬 [Theme Variants](https://github.com/JakeNavith/tailwindcss-theme-variants) - Adds them variants based on media queries and/or CSS selectors.
 - 🎨🧬 [Multi Theme](https://github.com/estevanmaito/tailwindcss-multi-theme) - Adds theme variants based on a single `theme` property.
@@ -139,6 +140,7 @@
 - 🛑🧬 [CSS Alpha Colors](https://github.com/soueuls/tailwind-color-alpha) - Adds opacity variants to existing colors.
 - 🛑🧩 [Spinner](https://github.com/aniftyco/tailwindcss-spinner) - Adds a spinner component.
 - 🛑🧩 [Spaced Items](https://github.com/n1kk/tailwindcss-spaced-items) - Adds `spaced` components that add fixed margins to all container items.
+- 🛑🧩💙 [Custom Forms](https://github.com/tailwindlabs/tailwindcss-custom-forms) - Adds better default styles to form elements.
 
 ## Tools
 


### PR DESCRIPTION
| Name                 | Link                 |
| -------------------- | -------------------- |
| Aspect Ratio | https://github.com/tailwindlabs/tailwindcss-aspect-ratio |
| Forms | https://github.com/tailwindlabs/tailwindcss-forms |

This PR adds [Aspect Ratio]90, a new official plugin for adding composable aspect ratio utilities. 
It also deprecates [Custom Forms](https://github.com/tailwindlabs/tailwindcss-custom-forms), even though it's not yet deprecated, because [Forms](https://github.com/tailwindlabs/tailwindcss-forms) will be its successor. 

**Note**: I'm going ahead by deprecating Custom Forms in the list to make it clear that Forms is the new recommended plugin, but since it's not *yet* deprecated, feel free to ask me to un-deprecate it for now if you feel we should wait.

---

- [x] My item is in the right category
- [x] My item is logically grouped below similar items
- [x] My item's name and description respects the conventions of the list
- [x] My item is awesome
- [x] I have read and followed the [contribution guidelines](.github/CONTRIBUTING.md)
