### PR TITLE
remove(components): Daisy UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,6 @@
 - 🧩 [lofi ui](https://lofiui.co/) - Low-fidelity Tailwind CSS components.
 - 🧩 [Gust UI](https://www.gustui.com/) - Sleek Tailwind CSS components for web applications in React and HTML.
 - 🧩 [Windstrap](https://windstrap.netlify.app) - Tailwind CSS with Bootstrap JS.
-- 🧩 [Daisy UI](https://github.com/saadeghi/daisyui) - Themeable UI components library.
 - 📁 [Windmill Dashboard](https://windmill-dashboard.vercel.app/) - Multi theme, completely accessible dashboard template.
 - 📁 [Tailwind Admin](https://github.com/tailwindadmin/admin) - Administration panel template with Tailwind CSS.
 - 📁 [Landing Gradients](https://landing-gradients.netlify.app/) - Landing page template using gradients (1.7+).


### PR DESCRIPTION
This reverts adding Daisy UI as the link, repo, and user account seem to be 404 now.