### PR TITLE
add(tools): tailwindcss-rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@
 - 💼 [preact-cli-tailwind](https://github.com/agneym/preact-cli-tailwind) - Tailwind CSS integration for Preact.
 - 💼 [tailwind-classes-sorter](https://github.com/Acidic9/tailwind-classes-sorter) - NPM library which provides a utility to sort Tailwind CSS classes.
 - 💼 [prettier-plugin-tailwind](https://github.com/Acidic9/prettier-plugin-tailwind) - Prettier plugin that sorts class lists.
+- 💼 [tailwindcss-rails](https://github.com/rails/tailwindcss-rails) - Gem for using Tailwind CSS with Rails' asset pipeline.
 - 💼🔧 [Zeplin Config & Class generator](https://extensions.zeplin.io/5ae2d20017c57fd249c9876f) - Zeplin extension that generates Tailwind configurations.
 - 💼🔧 [@tailwindcssinjs/macro](https://github.com/Arthie/tailwindcssinjs) - Babel macro that transforms Tailwind CSS classes into objects for CSS-in-JS libraries.
 - 💼🔧 [twin.macro](https://github.com/ben-rogerson/twin.macro) - Use Tailwind classes within any CSS-in-JS library.


### PR DESCRIPTION
| Name                 | Link                 |
| -------------------- | -------------------- |
| tailwindcss-rails | https://github.com/rails/tailwindcss-rails |

This is a new Ruby gem for using Tailwind CSS with Ruby on Rails' pipeline. For standard (configurable) use, Tailwind should still be installed with webpacker, but I thought this still belongs on the list.

More context: https://twitter.com/dhh/status/1349722147845976065

---

- [x] My item is in the right category
- [x] My item is logically grouped below similar items
- [x] My item's name and description respects the conventions of the list
- [x] My item is awesome
- [x] I have read and followed the [contribution guidelines](.github/CONTRIBUTING.md)
