### PR TITLE
add(plugins): tailwindcss-pseudo-selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@
 - 🧬 [Padded Radius](https://github.com/locksten/tailwindcss-padded-radius) - Adds variants for matching nested border radii.
 - 🧬 [Fluid](https://github.com/soberwp/tailwindcss-fl) - Generates `fl:` variants.
 - 🧬 [Marker](https://github.com/RadishIO/tailwindcss-marker) - Provides utilities for styling lists and `<summary>` markers.
+- 🧬 [Pseudo selectors](https://github.com/Microwawe/tailwindcss-pseudo-selectors) - Adds variants for the pseudo-classes and pseudo-elements that Tailwind CSS doesn't have by default.
 - 🧩 [Debug Screens](https://github.com/jorenvanhee/tailwindcss-debug-screens) - Adds a component that shows the currently active screen (responsive breakpoint).
 - 🧩 [Heropatterns](https://github.com/AndreaMinato/tailwind-heropatterns) - Adds [Hero Patterns](https://www.heropatterns.com) components.
 - 🧩 [Responsive Embed](https://github.com/drdogbot7/tailwindcss-responsive-embed) - Adds a `responsive-embed` component.


### PR DESCRIPTION
| Name                 | Link                 |
| -------------------- | -------------------- |
| tailwindcss-pseudo-selectors | [github](https://github.com/Microwawe/tailwindcss-pseudo-selectors) / [npmjs](https://www.npmjs.com/package/tailwindcss-pseudo-selectors) |

A plugin that adds support for all the rest of the  (non-experimental) pseudo selectors from the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes) that Tailwind CSS doesn't have, such as `:valid` and `:invalid`. 

---

- [x] My item is in the right category
- [x] My item is logically grouped below similar items
- [x] My item's name and description respects the conventions of the list
- [x] My item is awesome
- [x] I have read and followed the [contribution guidelines](.github/CONTRIBUTING.md)
