### PR TITLE
add(utilities): tailwindcss-no-scrollbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@
 - 💼 [Scrollbar Hide](https://github.com/reslear/tailwind-scrollbar-hide) - Adds `scrollbar-hide` class for visual hide scrollbar.
 - 💼 [Downwind CSS Easings](https://github.com/downwindcss/easings) - Extends `transition-timing-function` utilities.
 - 💼 [Content Placeholder](https://github.com/javisperez/tailwindcontentplaceholder) - Adds utilities for content placeholder images.
+- 💼 [No Scrollbar](https://github.com/redwebcreation/tailwindcss-no-scrollbar) - Exposes `scrollbar-none` to visually hide a scrollbar.
 - 🧬 [Pseudo](https://github.com/Log1x/tailwindcss-pseudo) - Adds custom variants to Tailwind CSS's configuration.
 - 🧬 [Direction](https://github.com/RonMelkhior/tailwindcss-dir) - Adds `RTL` and `LTR` variants.
 - 🧬 [Touch](https://github.com/SteadfastCollective/tailwindcss-touch) - Adds `touch` variants.


### PR DESCRIPTION
| Name                 | Link                 |
| -------------------- | -------------------- |
|Tailwind CSS plugin for removing scrollbars | https://github.com/redwebcreation/tailwindcss-no-scrollbar |

This plugin exposes a class that hides the browser's default scrollbar using various tricks

---

- [x] My item is in the right category
- [x] My item is logically grouped below similar items
- [x] My item's name and description respects the conventions of the list
- [x] My item is awesome
- [x] I have read and followed the [contribution guidelines](.github/CONTRIBUTING.md)
