### PR TITLE
fix(pr-template): update guidelines link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,4 @@ _Resource description here_
 - [ ] My item is logically grouped below similar items
 - [ ] My item's name and description respects the conventions of the list
 - [ ] My item is awesome
-- [ ] I have read and followed the [contribution guidelines](.github/CONTRIBUTING.md)
+- [ ] I have read and followed the [contribution guidelines](https://github.com/aniftyco/awesome-tailwindcss/blob/master/.github/CONTRIBUTING.md)


### PR DESCRIPTION
The link is broken in PRs because it is relative. Changed it to an absolute one.