### PR TITLE
add(plugins): tailwind-accent-color

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@
 - 💼 [Downwind CSS Easings](https://github.com/downwindcss/easings) - Extends `transition-timing-function` utilities.
 - 💼 [Content Placeholder](https://github.com/javisperez/tailwindcontentplaceholder) - Adds utilities for content placeholder images.
 - 💼 [No Scrollbar](https://github.com/redwebcreation/tailwindcss-no-scrollbar) - Exposes `scrollbar-none` to visually hide a scrollbar.
+- 💼 [Accent Color](https://github.com/lukewarlow/tailwind-accent-color) - Adds accent color utilities.
 - 🧬 [Pseudo](https://github.com/Log1x/tailwindcss-pseudo) - Adds custom variants to Tailwind CSS's configuration.
 - 🧬 [Direction](https://github.com/RonMelkhior/tailwindcss-dir) - Adds `RTL` and `LTR` variants.
 - 🧬 [Touch](https://github.com/SteadfastCollective/tailwindcss-touch) - Adds `touch` variants.


### PR DESCRIPTION
| Name                 | Link                 |
| -------------------- | -------------------- |
| Tailwind Accent Color | https://github.com/lukewarlow/tailwind-accent-color |

Tailwind Accent Color is a plugin used to generate [accent color classes / styles](https://drafts.csswg.org/css-ui-4/#widget-accent) with `accent-<color>`.

Right now this is only a feature in Chrome, and requires the user to activate a flag, though we'll likely see adoption pick up soon here. 

---

- [X] My item is in the right category
- [X] My item is logically grouped below similar items
- [X] My item's name and description respects the conventions of the list
- [X] My item is awesome
- [X] I have read and followed the [contribution guidelines](https://github.com/aniftyco/awesome-tailwindcss/blob/master/.github/CONTRIBUTING.md)
