### PR TITLE
feat(pr-template): explicitly add brand guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,5 @@ _Resource description here_
 - [ ] My item is logically grouped below similar items
 - [ ] My item's name and description respects the conventions of the list
 - [ ] My item is awesome
+- [ ] My item is in line with the [Tailwind brand usage guidelines](https://tailwindcss.com/brand#usage)
 - [ ] I have read and followed the [contribution guidelines](https://github.com/aniftyco/awesome-tailwindcss/blob/master/.github/CONTRIBUTING.md)


### PR DESCRIPTION
I feel like this will prevent people from skipping the part that says "Please do not use the Tailwind name … in any way that could mistakenly imply any official connection with or endorsement of Tailwind Labs Inc." (or at least make it less likely).