### PR TITLE
Add Capitalize first letter to plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@
 - 💼 [Scroll Behavior](https://github.com/lukewarlow/tailwind-scroll-behavior) - Adds `scroll-smooth` and `scroll-auto` classes to control smooth scrolling.
 - 💼 [Accent Color](https://github.com/lukewarlow/tailwind-accent-color) - Adds accent color utilities.
 - 💼 [Downwind CSS Text Decoration](https://github.com/downwindcss/text-decoration) - Adds composable `text-decoration` utilities.
+- 💼 [Capitalize first letter](https://github.com/riderx/capitalize-first-tailwind) - Adds `capitalize-first` utilities.
 - 🧬 [Direction](https://github.com/RonMelkhior/tailwindcss-dir) - Adds `RTL` and `LTR` variants.
 - 🧬 [Touch](https://github.com/SteadfastCollective/tailwindcss-touch) - Adds `touch` variants.
 - 🧬 [Alpha](https://github.com/bradlc/tailwindcss-alpha) - Adds alpha color variants.


### PR DESCRIPTION
| Name                 | Link                 |
| -------------------- | -------------------- |
| Capitalize first letter | https://github.com/riderx/capitalize-first-tailwind |

Tailwind plugin that adds utility for capitalize the first letter of the string.
Super useful when all your string come from i18n text and cannot be changed.

---

- [X] My item is in the right category
- [X] My item is logically grouped below similar items
- [X] My item's name and description respects the conventions of the list
- [X] My item is awesome
- [X] My item is in line with the [Tailwind brand usage guidelines](https://tailwindcss.com/brand#usage)
- [X] I have read and followed the [contribution guidelines](https://github.com/aniftyco/awesome-tailwindcss/blob/master/.github/CONTRIBUTING.md)
