### PR TITLE
remove(components): vue-tailwind-picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,6 @@
 - 🧩📁 [Treact](https://treact.owaiskhan.me) - React UI templates and components built using Tailwind CSS.
 - 🧩📁 [Jakarta LTE](https://github.com/zeroblack-c/jakarta-lte) - Admin template using Tailwind CSS.
 - 🧩📁 [themes.dev](https://www.themes.dev/) - Handcrafted, free and premium Tailwind CSS themes and components.
-- 🧩 [Date picker](https://github.com/kenhyuwa/vue-tailwind-picker) - Datepicker component for Vue.js using Tailwind CSS.
 - 🧩 [Kutty](https://kutty.netlify.app) - Accessible and reusable components that are commonly used in web applications.
 - 🧩 [Sail UI](https://sailui.github.io/) - Collection of basic UI components built on Tailwind CSS.
 - 🧩 [jQuery Toggler](https://craigerskine.github.io/jquery-tailwind-checkbox-toggle) - Switches using jQuery and Tailwind CSS.


### PR DESCRIPTION
The [Vue Tailwind Picker](https://github.com/kenhyuwa/vue-tailwind-picker)  project now advises to use Litepie

| Name                 | Link                 |
| -------------------- | -------------------- |
| _Resource name here_ | _Resource link here_ |

_Resource description here_

---

- [ ] My item is in the right category
- [ ] My item is logically grouped below similar items
- [ ] My item's name and description respects the conventions of the list
- [ ] My item is awesome
- [ ] My item is in line with the [Tailwind brand usage guidelines](https://tailwindcss.com/brand#usage)
- [x] I have read and followed the [contribution guidelines](https://github.com/aniftyco/awesome-tailwindcss/blob/master/.github/CONTRIBUTING.md)
