### PR TITLE
add(plugins): Grid Areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@
 - 💼 [Content Placeholder](https://github.com/javisperez/tailwindcontentplaceholder) - Adds utilities for content placeholder images.
 - 💼 [No Scrollbar](https://github.com/redwebcreation/tailwindcss-no-scrollbar) - Exposes `scrollbar-none` to visually hide a scrollbar.
 - 💼 [Fluid Type](https://github.com/davidhellmann/tailwindcss-fluid-type) - Adds fluid type (`font-size`) utilities.
+- 💼 [Grid Areas](https://github.com/SavvyWombat/tailwindcss-grid-areas) - Adds `grid-areas` and `grid-area` utilities.
 - 🧬 [Touch](https://github.com/SteadfastCollective/tailwindcss-touch) - Adds `touch` variants.
 - 🧬 [Localized](https://github.com/hdodov/tailwindcss-localized) - Adds variants based on the HTML `lang` attribute, to use utilities only with certain languages.
 - 🧬 [Padded Radius](https://github.com/locksten/tailwindcss-padded-radius) - Adds variants for matching nested border radii.


### PR DESCRIPTION
| Name                 | Link                 |
| -------------------- | -------------------- |
|  tailwindcss-grid-areas |  https://github.com/SavvyWombat/tailwindcss-grid-areas |

Adds utilities for `grid-areas` and `grid-area`.

---

- [ x ] My item is in the right category
- [ x ] My item is logically grouped below similar items
- [ x ] My item's name and description respects the conventions of the list
- [ x ] My item is awesome
- [ x ] My item is in line with the [Tailwind brand usage guidelines](https://tailwindcss.com/brand#usage)
- [ x ] I have read and followed the [contribution guidelines](https://github.com/aniftyco/awesome-tailwindcss/blob/master/.github/CONTRIBUTING.md)
