### PR TITLE
add(plugins): tailwindcss-accent

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
 - 🎨🧬 [Theme Swapper](https://github.com/crswll/tailwindcss-theme-swapper) - Theming using CSS variables, with media queries support.
 - 🎨🧬 [Themeable](https://github.com/upupming/tailwindcss-themeable) - Adds multiple themes support for Tailwind CSS.
 - 🎨🧬 [Themer](https://github.com/RyanClementsHax/tailwindcss-themer) - Adds theming support for Tailwind CSS with CSS variables and variants.
+- 🎨💼 [Accent](https://github.com/enjidev/tailwindcss-accent) - Adds `accent` colors for more dynamic and flexible color utilization.
 - 💼🧬 [Radix](https://github.com/ecklf/tailwindcss-radix) - Adds utilities and variants for styling Radix UI state.
 - 💼 [Custom Native](https://github.com/SirNavith/tailwindcss-custom-native) - Leverages Tailwind CSS's configuration to allow the creation of utilities.
 - 💼 [Image Rendering](https://github.com/hacknug/tailwindcss-image-rendering) - Adds `image-rendering` utilities.


### PR DESCRIPTION
| Name                 | Link                 |
| -------------------- | -------------------- |
| tailwindcss-accent   | [https://github.com/enjidev/tailwindcss-accent](https://github.com/enjidev/tailwindcss-accent) |

This plugin creates a dynamic accent color using CSS custom properties based on the Tailwind CSS default color palette.

It adds accent color utility classes to Tailwind CSS project, such as `bg-accent-500`, `dark:outline-accent-200`, etc.

It has been tested with Tailwind CSS versions 2 and 3.

---

- [x] My item is in the right category
- [x] My item is logically grouped below similar items
- [x] My item's name and description respects the conventions of the list
- [x] My item is awesome
- [x] My item is in line with the [Tailwind brand usage guidelines](https://tailwindcss.com/brand#usage)
- [x] I have read and followed the [contribution guidelines](https://github.com/aniftyco/awesome-tailwindcss/blob/master/.github/CONTRIBUTING.md)
