### PR TITLE
add(plugins): CSS Filter Order

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@
 - 💼 [Fluid Type](https://github.com/davidhellmann/tailwindcss-fluid-type) - Adds fluid type (`font-size`) utilities.
 - 💼 [Grid Areas](https://github.com/SavvyWombat/tailwindcss-grid-areas) - Adds `grid-areas` and `grid-area` utilities.
 - 💼 [Full Bleed Background and Borders](https://github.com/dgknca/tailwindcss-full-bleed) - Provides utilities for extended backgrounds and borders.
-- 💼 [CSS Filter Order](https://github.com/joshdavenport/tailwindcss-filter-order) - Adds `filter-order` utilties for changing the order Tailwind applies CSS filters.
+- 💼 [CSS Filter Order](https://github.com/joshdavenport/tailwindcss-filter-order) - Adds `filter-order` utilities for changing the order of filters in the generated CSS.
 - 🧬 [Touch](https://github.com/SteadfastCollective/tailwindcss-touch) - Adds `touch` variants.
 - 🧬 [Localized](https://github.com/hdodov/tailwindcss-localized) - Adds variants based on the HTML `lang` attribute, to use utilities only with certain languages.
 - 🧬 [Padded Radius](https://github.com/locksten/tailwindcss-padded-radius) - Adds variants for matching nested border radii.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@
 - 💼 [Fluid Type](https://github.com/davidhellmann/tailwindcss-fluid-type) - Adds fluid type (`font-size`) utilities.
 - 💼 [Grid Areas](https://github.com/SavvyWombat/tailwindcss-grid-areas) - Adds `grid-areas` and `grid-area` utilities.
 - 💼 [Full Bleed Background and Borders](https://github.com/dgknca/tailwindcss-full-bleed) - Provides utilities for extended backgrounds and borders.
+- 💼 [CSS Filter Order](https://github.com/joshdavenport/tailwindcss-filter-order) - Adds `filter-order` utilties for changing the order Tailwind applies CSS filters.
 - 🧬 [Touch](https://github.com/SteadfastCollective/tailwindcss-touch) - Adds `touch` variants.
 - 🧬 [Localized](https://github.com/hdodov/tailwindcss-localized) - Adds variants based on the HTML `lang` attribute, to use utilities only with certain languages.
 - 🧬 [Padded Radius](https://github.com/locksten/tailwindcss-padded-radius) - Adds variants for matching nested border radii.


### PR DESCRIPTION
| Name                 | Link                 |
| -------------------- | -------------------- |
| tailwindcss-filter-order | https://github.com/joshdavenport/tailwindcss-filter-order |

A plugin to order your CSS filters applied by Tailwind CSS. Order of filters passed to the filter property can drastically change the final result. Without use of this plugin filters are applied in the same order every time because Tailwind has a hardcoded order.

---

- [ x ] My item is in the right category
- [ x ] My item is logically grouped below similar items
- [ x ] My item's name and description respects the conventions of the list
- [ x ] My item is awesome
- [ x ] My item is in line with the [Tailwind brand usage guidelines](https://tailwindcss.com/brand#usage)
- [ x ] I have read and followed the [contribution guidelines](https://github.com/aniftyco/awesome-tailwindcss/blob/master/.github/CONTRIBUTING.md)
