### PR TITLE
add(plugins): Tailwind CSS Claymorphism

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@
 - 💼 [Full Bleed Background and Borders](https://github.com/dgknca/tailwindcss-full-bleed) - Provides utilities for extended backgrounds and borders.
 - 💼 [CSS Filter Order](https://github.com/joshdavenport/tailwindcss-filter-order) - Adds `filter-order` utilities for changing the order of filters in the generated CSS.
 - 💼 [TailwindCSS 3D](https://github.com/sambauers/tailwindcss-3d) - Adds 3D `transform` utilities and animations.
+- 💼 [Claymorphism](https://github.com/dulltackle/tailwindcss-claymorphism) - Adds `clay` utilities for creating claymorphism style.
 - 🧬 [Touch](https://github.com/SteadfastCollective/tailwindcss-touch) - Adds `touch` variants.
 - 🧬 [Localized](https://github.com/hdodov/tailwindcss-localized) - Adds variants based on the HTML `lang` attribute, to use utilities only with certain languages.
 - 🧬 [Padded Radius](https://github.com/locksten/tailwindcss-padded-radius) - Adds variants for matching nested border radii.


### PR DESCRIPTION
| Name                 | Link                 |
| -------------------- | -------------------- |
| Tailwind CSS Claymorphism plugin | _Resource link here_ |

Tailwind CSS Claymorphism plugin adds `clay` utilities for creating claymorphism style.

---

- [ x ] My item is in the right category
- [ x ] My item is logically grouped below similar items
- [ x ] My item's name and description respects the conventions of the list
- [ x ] My item is awesome
- [ x ] My item is in line with the [Tailwind brand usage guidelines](https://tailwindcss.com/brand#usage)
- [ x ] I have read and followed the [contribution guidelines](https://github.com/aniftyco/awesome-tailwindcss/blob/master/.github/CONTRIBUTING.md)
