### PR TITLE
add(tools): Fluid type scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@
 - 🌍🔧 [Tailwind Box Shadows Generator](https://manuarora.in/boxshadows) - Box Shadows generator.
 - 💰🌍🔧 [Windframe](https://www.devwares.com/windframe/) - Tailwind CSS drag and drop builder to rapidly build and prototype websites.
 - 🌍 [Static Tailwind](https://statictailwind.com) - The most used Tailwind classes, precompiled, with no build step.
+- 🔼🌍🔧 [Fluid Type Scale](https://www.fluid-type-scale.com) - Generate fluid font size variables with CSS clamp.
 
 ## UI Libraries, Components & Templates
 


### PR DESCRIPTION
Added Fluid type scale to tools section

| Name                 | Link                 |
| -------------------- | -------------------- |
| Fluid type scale | https://www.fluid-type-scale.com |

Generate font size variables for a fluid type scale with CSS clamp. Grab the output CSS and drop it into any design system.

---

- [x] My item is in the right category
- [x] My item is logically grouped below similar items
- [x] My item's name and description respects the conventions of the list
- [x] My item is awesome
- [x] My item is in line with the [Tailwind brand usage guidelines](https://tailwindcss.com/brand#usage)
- [x] I have read and followed the [contribution guidelines](https://github.com/aniftyco/awesome-tailwindcss/blob/master/.github/CONTRIBUTING.md)
