### PR TITLE
add(plugins): Dot & Grid Backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@
 - 🧬 [FormKit](https://github.com/formkit/formkit/tree/master/packages/tailwindcss) - Adds variants for input and form states for FormKit.
 - 🧬 [Htmx](https://github.com/aniftyco/tailwind-htmx) - Adds variants for styling on [htmx](https://htmx.org/reference/#classes) events.
 - 🧩 [Debug screens](https://github.com/jorenvanhee/tailwindcss-debug-screens) - Adds a component that shows the currently active screen (responsive breakpoint).
-- 💼 [Dot & Grid Backgrounds](https://github.com/TheNaubit/tailwind-dot-grid-backgrounds) - Adds `bg-grid` and `bg-dot` classes to add easy to customize grid and dot pattern backgrounds with just CSS.
+- 💼 [Dot & Grid Backgrounds](https://github.com/TheNaubit/tailwind-dot-grid-backgrounds) - Adds `bg-grid` and `bg-dot` classes to add easy-to-customize grid and dot pattern backgrounds with just CSS.
 
 
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 - 🧬 [FormKit](https://github.com/formkit/formkit/tree/master/packages/tailwindcss) - Adds variants for input and form states for FormKit.
 - 🧬 [Htmx](https://github.com/aniftyco/tailwind-htmx) - Adds variants for styling on [htmx](https://htmx.org/reference/#classes) events.
 - 🧩 [Debug screens](https://github.com/jorenvanhee/tailwindcss-debug-screens) - Adds a component that shows the currently active screen (responsive breakpoint).
+- 💼 [Dot & Grid Backgrounds](https://github.com/TheNaubit/tailwind-dot-grid-backgrounds) - Adds `bg-grid` and `bg-dot` classes to add easy to customize grid and dot pattern backgrounds with just CSS.
 
 
 


### PR DESCRIPTION
| Name                 | Link                 |
| -------------------- | -------------------- |
| Dot & Grid Backgrounds | https://github.com/TheNaubit/tailwind-dot-grid-backgrounds |

 Adds `bg-grid` and `bg-dot` classes to add easy-to-customize grid and dot pattern backgrounds with just CSS.

---

- [x] My item is in the right category
- [x] My item is logically grouped below similar items
- [x] My item's name and description respects the conventions of the list
- [x] My item is awesome
- [x] My item is in line with the [Tailwind brand usage guidelines](https://tailwindcss.com/brand#usage)
- [x] I have read and followed the [contribution guidelines](https://github.com/aniftyco/awesome-tailwindcss/blob/master/.github/CONTRIBUTING.md)
