### PR TITLE
add(tools): Screen Size Overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@
 - 💼 [Raycast Extension](https://www.raycast.com/vimtor/tailwindcss) - Search classes, documentation and colors in Raycast Launcher.
 - 💼 [DivMagic](https://divmagic.com) - Copy any web element and style as Tailwind CSS component.
 - 💼 [Gimli Tailwind](https://chromewebstore.google.com/detail/gimli-tailwind/fojckembkmaoehhmkiomebhkcengcljl) - Smart tools for Tailwind CSS as a browser extension.
+- 💼 [Screen Size Overlay](https://github.com/iwebexpert/screen-size-overlay) - Displays a real-time screen size overlay using Tailwind CSS breakpoints in React/Next.js, highlighting screen dimensions and nearest breakpoints for easier debugging.
 - 🌍 [Tailwind Cheat Sheet](https://tailwindcomponents.com/cheatsheet) - Tailwind CSS class names in a searchable page.
 - 🌍🔧 [Tailwind Grid Generator](https://www.tailwindgen.com/) - Drag and drop Tailwind CSS grid generator.
 - 🌍🔧 [Tailwind Box Shadows Generator](https://manuarora.in/boxshadows) - Box Shadows generator.


### PR DESCRIPTION
| Name                 | Link                 |
| -------------------- | -------------------- |
|Screen Size Overlay |https://github.com/iwebexpert/screen-size-overlay|

Screen Size Overlay is a lightweight React component that displays the current screen size (width and height), shows distances to the previous and next breakpoints. Supports presets (Tailwind CSS, Bootstrap, Foundation, Bulma, MUI) or fully custom configurations. By default, screen-size-overlay uses `Tailwind CSS` breakpoints.

---

- [x] My item is in the right category
- [x] My item is logically grouped below similar items
- [x] My item's name and description respects the conventions of the list
- [x] My item is awesome
- [x] My item is in line with the [Tailwind brand usage guidelines](https://tailwindcss.com/brand#usage)
- [x] I have read and followed the [contribution guidelines](https://github.com/aniftyco/awesome-tailwindcss/blob/master/CONTRIBUTING.md)
