### PR TITLE
add(plugin): Tailwind CSS px to viewport

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@
 - 💼 [Tailwind CSS 3D](https://github.com/sambauers/tailwindcss-3d) - Adds 3D `transform` utilities and animations.
 - 💼 [Claymorphism](https://github.com/dulltackle/tailwindcss-claymorphism) - Adds `clay` utilities for creating claymorphism style.
 - 💼🧬🧩 [Fluid](https://github.com/barvian/fluid-tailwind) - Adds fluid `clamp()` versions of every built-in utility.
+- 💼 [tailwindcss-px-to-viewport](https://github.com/the-lemonboy/tailwindcss-px-to-viewport) - Adds utilities to automatically convert px to vw / vh.
 - 🧬 [FormKit](https://github.com/formkit/formkit/tree/master/packages/tailwindcss) - Adds variants for input and form states for FormKit.
 - 🧬 [Htmx](https://github.com/aniftyco/tailwind-htmx) - Adds variants for styling on [htmx](https://htmx.org/reference/#classes) events.
 - 🧬 [Quantity Queries](https://github.com/skttl/tailwindcss-quantity-queries) - Adds variants for using quantity queries.


### PR DESCRIPTION
| Name                 | Link                 |
| -------------------- | -------------------- |
| _tailwindcss-px-to-viewport_ | _[tailwindcss-px-to-viewport](https://github.com/the-lemonboy/tailwindcss-px-to-viewport)_ |

_Tailwind CSS plugin that automatically converts **px** unit properties to viewport units **vw** or **vh**._

---

- [x] My item is in the right category  
- [x] My item is logically grouped below similar items  
- [x] My item's name and description respects the conventions of the list  
- [x] My item is awesome  
- [x] My item is in line with the [Tailwind brand usage guidelines](https://tailwindcss.com/brand#usage)  
- [x] I have read and followed the [contribution guidelines](https://github.com/aniftyco/awesome-tailwindcss/blob/master/CONTRIBUTING.md)  
